### PR TITLE
feat: add GetSupplier method to ContextHelper interface

### DIFF
--- a/.idea/go.imports.xml
+++ b/.idea/go.imports.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GoImports">
+    <option name="excludedPackages">
+      <array>
+        <option value="github.com/pkg/errors" />
+        <option value="golang.org/x/net/context" />
+      </array>
+    </option>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/helpers.go
+++ b/helpers.go
@@ -10,6 +10,15 @@ type contextHelper struct {
 	authenticator Authenticator
 }
 
+func (helper *contextHelper) GetSupplier(request connect.AnyRequest) string {
+	supplierID := request.Header().Get(XSupplierKey)
+	if supplierID == "" {
+		return ""
+	}
+
+	return supplierID
+}
+
 func (helper *contextHelper) GetToken(req connect.AnyRequest) string {
 	accessToken := req.Header().Get("Authorization")
 	if accessToken == "" {

--- a/types.go
+++ b/types.go
@@ -20,6 +20,7 @@ type ContextHelper interface {
 	GetTenant(ctx context.Context) (string, string)
 	GetUserClaims(context.Context) *Claims
 	GetToken(in connect.AnyRequest) string
+	GetSupplier(connect.AnyRequest) string
 }
 
 type Config interface {


### PR DESCRIPTION
Add GetSupplier to the ContextHelper interface and implement it on contextHelper. The method extracts the supplier ID from the request header using XSupplierKey.